### PR TITLE
Refactor LlamaAPIManager: Modularize API Request Logic and Implement analyzeInnerText for InnerText Analysis

### DIFF
--- a/glanceables.xcodeproj/project.pbxproj
+++ b/glanceables.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		03A868572C48880600CCB79D /* Response.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A868562C48880600CCB79D /* Response.swift */; };
 		03A868592C489B3100CCB79D /* JavascriptLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A868582C489B3100CCB79D /* JavascriptLoader.swift */; };
 		03A8685B2C4B312E00CCB79D /* LlamaResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A8685A2C4B312E00CCB79D /* LlamaResult.swift */; };
+		03A868612C4F0FB300CCB79D /* WebViewCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A868602C4F0FB300CCB79D /* WebViewCoordinator.swift */; };
 		03C5DAD12C23A76B0061FA25 /* ScreenshotUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03C5DAD02C23A76B0061FA25 /* ScreenshotUtils.swift */; };
 		03C5DAD32C24F0CF0061FA25 /* URLUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03C5DAD22C24F0CF0061FA25 /* URLUtilities.swift */; };
 		03C5DAD52C2647E20061FA25 /* CaptureModeToggleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03C5DAD42C2647E20061FA25 /* CaptureModeToggleView.swift */; };
@@ -80,6 +81,7 @@
 		03A868562C48880600CCB79D /* Response.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Response.swift; sourceTree = "<group>"; };
 		03A868582C489B3100CCB79D /* JavascriptLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JavascriptLoader.swift; sourceTree = "<group>"; };
 		03A8685A2C4B312E00CCB79D /* LlamaResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LlamaResult.swift; sourceTree = "<group>"; };
+		03A868602C4F0FB300CCB79D /* WebViewCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewCoordinator.swift; sourceTree = "<group>"; };
 		03C5DAD02C23A76B0061FA25 /* ScreenshotUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ScreenshotUtils.swift; path = glanceables/Utilities/ScreenshotUtils.swift; sourceTree = SOURCE_ROOT; };
 		03C5DAD22C24F0CF0061FA25 /* URLUtilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLUtilities.swift; sourceTree = "<group>"; };
 		03C5DAD42C2647E20061FA25 /* CaptureModeToggleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureModeToggleView.swift; sourceTree = "<group>"; };
@@ -150,7 +152,6 @@
 				03A8685F2C4EE63500CCB79D /* Utilities */,
 				03A868542C48871000CCB79D /* LlamaAPIManager.swift */,
 				03A868562C48880600CCB79D /* Response.swift */,
-				03A868582C489B3100CCB79D /* JavascriptLoader.swift */,
 				038208DF2C1BB3F400606536 /* WebViewScreenshotCapture.swift */,
 				03A8685E2C4EE5B300CCB79D /* ViewModel */,
 				03A8685C2C4EE50600CCB79D /* Model */,
@@ -204,6 +205,7 @@
 			isa = PBXGroup;
 			children = (
 				036D58E62C3CC8460042D491 /* WebClipUserDefaultsViewModel.swift */,
+				03A868602C4F0FB300CCB79D /* WebViewCoordinator.swift */,
 				036D58E42C3C99300042D491 /* WebClipEditorViewModel.swift */,
 				03553FE22C41F6A800FCB4CC /* WebPreviewCaptureMenuViewModel.swift */,
 			);
@@ -214,6 +216,7 @@
 			isa = PBXGroup;
 			children = (
 				03C5DAD02C23A76B0061FA25 /* ScreenshotUtils.swift */,
+				03A868582C489B3100CCB79D /* JavascriptLoader.swift */,
 				03C5DAD22C24F0CF0061FA25 /* URLUtilities.swift */,
 			);
 			path = Utilities;
@@ -352,6 +355,7 @@
 				03C5DAD92C2A4DB20061FA25 /* AddURLFormView.swift in Sources */,
 				030062A72C0FE8A100B0242D /* WebPreviewCaptureMenuView.swift in Sources */,
 				03C5DAD12C23A76B0061FA25 /* ScreenshotUtils.swift in Sources */,
+				03A868612C4F0FB300CCB79D /* WebViewCoordinator.swift in Sources */,
 				0378B8672C096D850005BAE5 /* glanceablesApp.swift in Sources */,
 				030062B42C112BD100B0242D /* WebClip.swift in Sources */,
 				03A868532C48692A00CCB79D /* SaveButtonView.swift in Sources */,

--- a/glanceables.xcodeproj/project.pbxproj
+++ b/glanceables.xcodeproj/project.pbxproj
@@ -17,7 +17,7 @@
 		036D58E52C3C99300042D491 /* WebClipEditorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 036D58E42C3C99300042D491 /* WebClipEditorViewModel.swift */; };
 		036D58E72C3CC8460042D491 /* WebClipUserDefaultsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 036D58E62C3CC8460042D491 /* WebClipUserDefaultsViewModel.swift */; };
 		03778E402C35E740009CB9A1 /* captureElements.js in Resources */ = {isa = PBXBuildFile; fileRef = 03778E3E2C35E6FC009CB9A1 /* captureElements.js */; };
-		03778E422C36028F009CB9A1 /* CapturedElements.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03778E412C36028F009CB9A1 /* CapturedElements.swift */; };
+		03778E422C36028F009CB9A1 /* CapturedElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03778E412C36028F009CB9A1 /* CapturedElement.swift */; };
 		0378B8672C096D850005BAE5 /* glanceablesApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0378B8662C096D850005BAE5 /* glanceablesApp.swift */; };
 		0378B8692C096D850005BAE5 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0378B8682C096D850005BAE5 /* ContentView.swift */; };
 		0378B86D2C096D860005BAE5 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0378B86C2C096D860005BAE5 /* Assets.xcassets */; };
@@ -64,7 +64,7 @@
 		036D58E42C3C99300042D491 /* WebClipEditorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebClipEditorViewModel.swift; sourceTree = "<group>"; };
 		036D58E62C3CC8460042D491 /* WebClipUserDefaultsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebClipUserDefaultsViewModel.swift; sourceTree = "<group>"; };
 		03778E3E2C35E6FC009CB9A1 /* captureElements.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = captureElements.js; sourceTree = "<group>"; };
-		03778E412C36028F009CB9A1 /* CapturedElements.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CapturedElements.swift; sourceTree = "<group>"; };
+		03778E412C36028F009CB9A1 /* CapturedElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CapturedElement.swift; sourceTree = "<group>"; };
 		0378B8632C096D850005BAE5 /* glanceables.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = glanceables.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		0378B8662C096D850005BAE5 /* glanceablesApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = glanceablesApp.swift; sourceTree = "<group>"; };
 		0378B8682C096D850005BAE5 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -176,7 +176,7 @@
 			isa = PBXGroup;
 			children = (
 				0300629A2C0D209400B0242D /* UserDefaults.swift */,
-				03778E412C36028F009CB9A1 /* CapturedElements.swift */,
+				03778E412C36028F009CB9A1 /* CapturedElement.swift */,
 				03A8685A2C4B312E00CCB79D /* LlamaResult.swift */,
 				030062B32C112BD100B0242D /* WebClip.swift */,
 			);
@@ -336,7 +336,7 @@
 				030062972C0A7F2600B0242D /* HeaderView.swift in Sources */,
 				03A8685B2C4B312E00CCB79D /* LlamaResult.swift in Sources */,
 				03A868512C4865C900CCB79D /* CaptureRectangleView.swift in Sources */,
-				03778E422C36028F009CB9A1 /* CapturedElements.swift in Sources */,
+				03778E422C36028F009CB9A1 /* CapturedElement.swift in Sources */,
 				0378B8772C096DB00005BAE5 /* WebGridSingleSnapshotView.swift in Sources */,
 				0378B8692C096D850005BAE5 /* ContentView.swift in Sources */,
 				038208E02C1BB3F400606536 /* WebViewScreenshotCapture.swift in Sources */,

--- a/glanceables.xcodeproj/project.pbxproj
+++ b/glanceables.xcodeproj/project.pbxproj
@@ -148,7 +148,6 @@
 				03DF92F42C40B98A00625AEB /* glanceables.entitlements */,
 				03A8685D2C4EE54200CCB79D /* View */,
 				03A8685F2C4EE63500CCB79D /* Utilities */,
-				038208E12C1BB40400606536 /* WebViewSnapshotRefresher.swift */,
 				03A868542C48871000CCB79D /* LlamaAPIManager.swift */,
 				03A868562C48880600CCB79D /* Response.swift */,
 				03A868582C489B3100CCB79D /* JavascriptLoader.swift */,
@@ -195,6 +194,7 @@
 				0378B8762C096DB00005BAE5 /* WebGridSingleSnapshotView.swift */,
 				030062982C0A833200B0242D /* CreateButtonView.swift */,
 				03A868522C48692A00CCB79D /* SaveButtonView.swift */,
+				038208E12C1BB40400606536 /* WebViewSnapshotRefresher.swift */,
 				03C5DAD62C264BE00061FA25 /* RedXButton.swift */,
 			);
 			path = View;

--- a/glanceables/JavascriptLoader.swift
+++ b/glanceables/JavascriptLoader.swift
@@ -11,4 +11,49 @@ struct JavaScriptLoader {
         let userScript = WKUserScript(source: scriptContent, injectionTime: .atDocumentStart, forMainFrameOnly: false)
         webView.configuration.userContentController.addUserScript(userScript)
     }
+    
+    static func injectGetElementsFromSelectorsScript(webView: WKWebView, elementSelector: String) {
+        let jsCode = """
+        (function() {
+            function restoreElements() {
+                try {
+                    const elementSelector = "\(elementSelector)";
+                    const elements = document.querySelectorAll(elementSelector);
+                    const selectors = Array.from(elements).map(element => {
+                        return {selector: elementSelector, text: element.innerText, outerHTML: element.outerHTML};
+                    });
+                    
+                    window.webkit.messageHandlers.elementsFromSelectorsHandler.postMessage(JSON.stringify(selectors));
+                } catch (error) {
+                    console.error('Error in script:', error);
+                    window.webkit.messageHandlers.elementsFromSelectorsHandler.postMessage('Error: ' + error.message);
+                }
+            }
+        
+            function watchForElement() {
+                const elementSelector = "\(elementSelector)";
+                const observer = new MutationObserver((mutationsList, observer) => {
+                    const elements = document.querySelectorAll(elementSelector);
+                    if (elements.length > 0) {
+                        restoreElements();
+                        observer.disconnect(); // Stop observing once elements are found
+                    }
+                });
+        
+                observer.observe(document.body, { childList: true, subtree: true });
+        
+                // Check if the elements are already present
+                const elements = document.querySelectorAll(elementSelector);
+                if (elements.length > 0) {
+                    restoreElements();
+                    observer.disconnect();
+                }
+            }
+        
+            watchForElement();
+        })();
+        """
+        
+        webView.configuration.userContentController.addUserScript(WKUserScript(source: jsCode, injectionTime: .atDocumentEnd, forMainFrameOnly: false))
+    }
 }

--- a/glanceables/Model/CapturedElement.swift
+++ b/glanceables/Model/CapturedElement.swift
@@ -1,10 +1,3 @@
-//
-//  CapturedElements.swift
-//  glanceables
-//
-//  Created by Devin Liu on 7/3/24.
-//
-
 import Foundation
 
 struct CapturedElement: Codable {
@@ -17,5 +10,6 @@ struct CapturedElement: Codable {
 
 struct HTMLElement: Codable {
     let outerHTML: String
+    let innerText: String
     
 }

--- a/glanceables/Utilities/JavascriptLoader.swift
+++ b/glanceables/Utilities/JavascriptLoader.swift
@@ -7,7 +7,7 @@ struct JavaScriptLoader {
             print("Failed to load JavaScript file: \(resourceName).\(extensionType)")
             return
         }
-
+        
         let userScript = WKUserScript(source: scriptContent, injectionTime: .atDocumentStart, forMainFrameOnly: false)
         webView.configuration.userContentController.addUserScript(userScript)
     }

--- a/glanceables/Utilities/JavascriptLoader.swift
+++ b/glanceables/Utilities/JavascriptLoader.swift
@@ -20,7 +20,7 @@ struct JavaScriptLoader {
                     const elementSelector = "\(elementSelector)";
                     const elements = document.querySelectorAll(elementSelector);
                     const selectors = Array.from(elements).map(element => {
-                        return {selector: elementSelector, text: element.innerText, outerHTML: element.outerHTML};
+                        return {selector: elementSelector, innerText: element.innerText, outerHTML: element.outerHTML};
                     });
                     
                     window.webkit.messageHandlers.elementsFromSelectorsHandler.postMessage(JSON.stringify(selectors));

--- a/glanceables/View/WebViewSnapshotRefresher.swift
+++ b/glanceables/View/WebViewSnapshotRefresher.swift
@@ -3,7 +3,7 @@ import WebKit
 import Combine
 
 struct WebViewSnapshotRefresher: UIViewRepresentable {
-    @ObservedObject private var viewModel = WebClipEditorViewModel.shared
+    @ObservedObject var viewModel = WebClipEditorViewModel.shared
     @ObservedObject var llamaAPIManager = LlamaAPIManager()
     let id: UUID
     var reloadTrigger: PassthroughSubject<Void, Never> // Add a reload trigger
@@ -36,8 +36,8 @@ struct WebViewSnapshotRefresher: UIViewRepresentable {
     }
     
     
-    func makeCoordinator() -> Coordinator {
-        Coordinator(self)
+    func makeCoordinator() -> WebViewCoordinator {
+        WebViewCoordinator(self)
     }
     
     
@@ -49,146 +49,6 @@ struct WebViewSnapshotRefresher: UIViewRepresentable {
         guard let firstElement = self.item?.capturedElements?.first else { return }
         let elementSelector = firstElement.selector
         JavaScriptLoader.injectGetElementsFromSelectorsScript(webView: webView, elementSelector: elementSelector)
-    }    
-    
-    class Coordinator: NSObject, WKNavigationDelegate, WKUIDelegate, UIScrollViewDelegate, WKScriptMessageHandler {
-        var parent: WebViewSnapshotRefresher
-        var webView: WKWebView?
-        var reloadSubscription: AnyCancellable?
-        var pageTitle: String?
-        
-        private var screenshotTrigger = PassthroughSubject<Void, Never>()
-        private var cancellables = Set<AnyCancellable>()
-        
-        init(_ parent: WebViewSnapshotRefresher) {
-            self.parent = parent
-            super.init()
-            
-            // Configure the throttle for screenshotTrigger
-            screenshotTrigger
-                .throttle(for: .seconds(60), scheduler: RunLoop.main, latest: true)
-                .sink { [weak self] in
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
-                        self?.captureScreenshot()
-                    }
-                }
-                .store(in: &cancellables)
-        }
-        
-        deinit {
-            reloadSubscription?.cancel()
-        }
-        
-        func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
-            let simplifiedPageTitle = URLUtilities.simplifyPageTitle(webView.title ?? "No Title")
-            self.pageTitle = simplifiedPageTitle
-            
-            if let capturedElements = self.parent.item?.capturedElements  {
-                self.restoreScrollPosition(capturedElements, in: webView)
-            }
-            
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1.1) {
-                // Restore scroll positions based on captured elements
-                if let capturedElements = self.parent.item?.capturedElements  {
-                    self.restoreScrollPosition(capturedElements, in: webView)
-                }
-                // Capture a screenshot
-                self.screenshotTrigger.send(())
-            }
-            
-            // Subscribe to the reload trigger
-            self.reloadSubscription = self.parent.reloadTrigger.sink {
-                webView.reload()
-                DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-                    self.captureScreenshot()
-                }
-            }
-        }
-        
-        // Method to restore the scroll position for captured elements
-        func restoreScrollPosition(_ elements: [CapturedElement], in webView: WKWebView) {
-            // Assuming 'CapturedElement' has properties like 'relativeTop' that can be used for scrolling
-            guard let firstElement = elements.first else { return }
-            let scrollScript = "window.scrollTo(0, \(firstElement.relativeTop));"
-            webView.evaluateJavaScript(scrollScript, completionHandler: { result, error in
-                if let error = error {
-                    print("Error while trying to scroll: \(error.localizedDescription)")
-                }
-            })
-        }
-        
-        func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
-            if message.name == "elementsFromSelectorsHandler", let messageBody = message.body as? String {
-                parseElementsFromSelectors(messageBody)
-            }
-        }
-        
-        func parseElementsFromSelectors(_ jsonString: String) {
-            guard let data = jsonString.data(using: .utf8) else {
-                print("Error: Cannot create data from jsonString")
-                return
-            }
-            
-            do {
-                let elements = try JSONDecoder().decode([HTMLElement].self, from: data)
-                processElements(elements)
-            } catch {
-                print("Error: \(error)")
-            }
-        }
-        
-        
-        func processElements(_ elements: [HTMLElement]) {
-            self.parent.llamaAPIManager.analyzeHTML(htmlElements: elements) { result in
-                switch result {
-                case .success(let result):
-                    self.parent.viewModel.updateWebClip(withId: self.parent.id, newLlamaResult: LlamaResult(conciseText: result))
-                    print("Generated result: \(result)")
-                    // Do something with the generated filename, e.g., update UI or model
-                case .failure(let error):
-                    print("Error interpreting changes: \(error.localizedDescription)")
-                }
-            }
-        }
-        
-        func captureScreenshot() {
-            guard let webView = webView else { return }
-            guard let item = self.parent.item else { return }
-            
-            
-            let configuration = WKSnapshotConfiguration()
-            if let clipRect = item.clipRect {
-                // Adjust clipRect based on the current zoom scale and content offset
-                let zoomScale = webView.scrollView.zoomScale
-                let offsetX = webView.scrollView.contentOffset.x
-                var y = clipRect.origin.y
-                
-                if let elements = item.capturedElements {
-                    if elements.first != nil {
-                        y = 0
-                    }
-                }
-                
-                let adjustedClipRect = CGRect(
-                    x: (clipRect.origin.x + offsetX) / zoomScale,
-                    y: y / zoomScale,
-                    width: clipRect.size.width / zoomScale,
-                    height: clipRect.size.height / zoomScale
-                )
-                
-                configuration.rect = adjustedClipRect
-            }
-            
-            webView.takeSnapshot(with: configuration) { image, error in
-                if let image = image {
-                    if let newScreenshotPath = ScreenshotUtils.saveScreenshotToFile(using: item, from: image) {
-                        if let item = self.parent.item {
-                            self.parent.viewModel.updateWebClip(withId: item.id, newScreenshotPath: newScreenshotPath)
-                        }
-                    }
-                }
-            }
-        }
     }
 }
 

--- a/glanceables/ViewModel/WebViewCoordinator.swift
+++ b/glanceables/ViewModel/WebViewCoordinator.swift
@@ -1,0 +1,143 @@
+import SwiftUI
+import WebKit
+import Combine
+
+class WebViewCoordinator: NSObject, WKNavigationDelegate, WKUIDelegate, UIScrollViewDelegate, WKScriptMessageHandler {
+    var parent: WebViewSnapshotRefresher
+    var webView: WKWebView?
+    var reloadSubscription: AnyCancellable?
+    var pageTitle: String?
+    
+    private var screenshotTrigger = PassthroughSubject<Void, Never>()
+    private var cancellables = Set<AnyCancellable>()
+    
+    init(_ parent: WebViewSnapshotRefresher) {
+        self.parent = parent
+        super.init()
+        
+        // Configure the throttle for screenshotTrigger
+        screenshotTrigger
+            .throttle(for: .seconds(60), scheduler: RunLoop.main, latest: true)
+            .sink { [weak self] in
+                DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
+                    self?.captureScreenshot()
+                }
+            }
+            .store(in: &cancellables)
+    }
+    
+    deinit {
+        reloadSubscription?.cancel()
+    }
+    
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        let simplifiedPageTitle = URLUtilities.simplifyPageTitle(webView.title ?? "No Title")
+        self.pageTitle = simplifiedPageTitle
+        
+        if let capturedElements = self.parent.item?.capturedElements  {
+            self.restoreScrollPosition(capturedElements, in: webView)
+        }
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.1) {
+            // Restore scroll positions based on captured elements
+            if let capturedElements = self.parent.item?.capturedElements  {
+                self.restoreScrollPosition(capturedElements, in: webView)
+            }
+            // Capture a screenshot
+            self.screenshotTrigger.send(())
+        }
+        
+        // Subscribe to the reload trigger
+        self.reloadSubscription = self.parent.reloadTrigger.sink {
+            webView.reload()
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                self.captureScreenshot()
+            }
+        }
+    }
+    
+    // Method to restore the scroll position for captured elements
+    func restoreScrollPosition(_ elements: [CapturedElement], in webView: WKWebView) {
+        // Assuming 'CapturedElement' has properties like 'relativeTop' that can be used for scrolling
+        guard let firstElement = elements.first else { return }
+        let scrollScript = "window.scrollTo(0, \(firstElement.relativeTop));"
+        webView.evaluateJavaScript(scrollScript, completionHandler: { result, error in
+            if let error = error {
+                print("Error while trying to scroll: \(error.localizedDescription)")
+            }
+        })
+    }
+    
+    func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+        if message.name == "elementsFromSelectorsHandler", let messageBody = message.body as? String {
+            parseElementsFromSelectors(messageBody)
+        }
+    }
+    
+    func parseElementsFromSelectors(_ jsonString: String) {
+        guard let data = jsonString.data(using: .utf8) else {
+            print("Error: Cannot create data from jsonString")
+            return
+        }
+        
+        do {
+            let elements = try JSONDecoder().decode([HTMLElement].self, from: data)
+            processElements(elements)
+        } catch {
+            print("Error: \(error)")
+        }
+    }
+    
+    
+    func processElements(_ elements: [HTMLElement]) {
+        self.parent.llamaAPIManager.analyzeHTML(htmlElements: elements) { result in
+            switch result {
+            case .success(let result):
+                self.parent.viewModel.updateWebClip(withId: self.parent.id, newLlamaResult: LlamaResult(conciseText: result))
+                print("Generated result: \(result)")
+                // Do something with the generated filename, e.g., update UI or model
+            case .failure(let error):
+                print("Error interpreting changes: \(error.localizedDescription)")
+            }
+        }
+    }
+    
+    func captureScreenshot() {
+        guard let webView = webView else { return }
+        guard let item = self.parent.item else { return }
+        
+        
+        let configuration = WKSnapshotConfiguration()
+        if let clipRect = item.clipRect {
+            // Adjust clipRect based on the current zoom scale and content offset
+            let zoomScale = webView.scrollView.zoomScale
+            let offsetX = webView.scrollView.contentOffset.x
+            var y = clipRect.origin.y
+            
+            if let elements = item.capturedElements {
+                if elements.first != nil {
+                    y = 0
+                }
+            }
+            
+            let adjustedClipRect = CGRect(
+                x: (clipRect.origin.x + offsetX) / zoomScale,
+                y: y / zoomScale,
+                width: clipRect.size.width / zoomScale,
+                height: clipRect.size.height / zoomScale
+            )
+            
+            configuration.rect = adjustedClipRect
+        }
+        
+        webView.takeSnapshot(with: configuration) { image, error in
+            if let image = image {
+                if let newScreenshotPath = ScreenshotUtils.saveScreenshotToFile(using: item, from: image) {
+                    if let item = self.parent.item {
+                        self.parent.viewModel.updateWebClip(withId: item.id, newScreenshotPath: newScreenshotPath)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/glanceables/ViewModel/WebViewCoordinator.swift
+++ b/glanceables/ViewModel/WebViewCoordinator.swift
@@ -82,15 +82,19 @@ class WebViewCoordinator: NSObject, WKNavigationDelegate, WKUIDelegate, UIScroll
         
         do {
             let elements = try JSONDecoder().decode([HTMLElement].self, from: data)
-            processElements(elements)
+            if let innerText = elements.last?.innerText {
+                print("InnerText result: ", innerText)
+                processElementsInnerText(innerText)
+            }
+            
         } catch {
             print("Error: \(error)")
         }
     }
     
     
-    func processElements(_ elements: [HTMLElement]) {
-        self.parent.llamaAPIManager.analyzeHTML(htmlElements: elements) { result in
+    func processElementsInnerText(_ innerText: String) {
+        self.parent.llamaAPIManager.analyzeInnerText(innerText: innerText) { result in
             switch result {
             case .success(let result):
                 self.parent.viewModel.updateWebClip(withId: self.parent.id, newLlamaResult: LlamaResult(conciseText: result))


### PR DESCRIPTION
Refactored the LlamaAPIManager class by modularizing the common API request logic and implementing the analyzeInnerText method. It also involves switching WebViewSnapshotRefresher from analyzing HTML code to analyzing inner text to speed up glanceable text generation.